### PR TITLE
Use rimraf instead of rm

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.0.8",
+    "@types/rimraf": "^3.0.0",
     "ansi-escapes": "^4.2.0",
     "chalk": "^2.4.2",
     "func": "^1.0.4",
@@ -20,6 +21,7 @@
     "ncc": "^0.3.6",
     "ora": "^3.4.0",
     "prompt-sync": "^4.1.7",
+    "rimraf": "^3.0.2",
     "ts-node": "^8.2.0",
     "tslint": "^5.17.0",
     "tslint-config-lambdas": "^1.1.0",

--- a/src/commands/major.ts
+++ b/src/commands/major.ts
@@ -2,6 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import { CommandMajor } from 'func'
 import { execSync } from 'child_process'
+import rimraf from 'rimraf'
 import * as print from '../utils/print'
 import * as spinner from '../utils/spinner'
 
@@ -53,7 +54,10 @@ export class Major {
   }
   
   async after(): Promise<void> {
-    execSync(`cd ${this.projectPath} && rm -rf .git .circle.yml .travis.yml .github now.json README_CN.md yarn.lock package-lock.json`)
+    const files = ['.git', '.circle.yml', '.travis.yml', '.github', 'now.json', 'README_CN.md', 'yarn.lock', 'package-lock.json']
+    for (const file of files) {
+      rimraf.sync(path.join(this.projectPath, file))
+    }
     const pkgPath = path.join(this.projectPath, 'package.json')
     if (!fs.existsSync(pkgPath)) return
     let pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'))

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,10 +18,36 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@types/glob@*":
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.3.tgz#e6ba80f36b7daad2c685acd9266382e68985c183"
+  integrity sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==
+  dependencies:
+    "@types/minimatch" "*"
+    "@types/node" "*"
+
+"@types/minimatch@*":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
+  integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
+
+"@types/node@*":
+  version "14.0.27"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.27.tgz#a151873af5a5e851b51b3b065c9e63390a9e0eb1"
+  integrity sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g==
+
 "@types/node@^12.0.8":
   version "12.0.8"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.8.tgz#551466be11b2adc3f3d47156758f610bd9f6b1d8"
   integrity sha512-b8bbUOTwzIY3V5vDTY1fIJ+ePKDUBqt2hC2woVGotdQQhG/2Sh62HOKHrT7ab+VerXAcPyAiTEipPu/FsreUtg==
+
+"@types/rimraf@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/rimraf/-/rimraf-3.0.0.tgz#b9d03f090ece263671898d57bb7bb007023ac19f"
+  integrity sha512-7WhJ0MdpFgYQPXlF4Dx+DhgvlPCfz/x5mHaeDQAKhcenvQP1KCpLQ18JklAqeGMYSAT2PxLpzd0g2/HE7fj7hQ==
+  dependencies:
+    "@types/glob" "*"
+    "@types/node" "*"
 
 ansi-escapes@^4.2.0:
   version "4.2.0"
@@ -346,6 +372,13 @@ rimraf@^2.6.1:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
+  dependencies:
+    glob "^7.1.3"
+
+rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 


### PR DESCRIPTION
To support platforms without `rm` utils.

Fix #1